### PR TITLE
add ingress rbac permissions

### DIFF
--- a/charts/alloy-operator/templates/rbac.yaml
+++ b/charts/alloy-operator/templates/rbac.yaml
@@ -152,9 +152,7 @@ rules:
     resources:
       - ingresses
     verbs:
-      - get
-      - list
-      - watch
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/alloy-operator/templates/rbac.yaml
+++ b/charts/alloy-operator/templates/rbac.yaml
@@ -153,6 +153,29 @@ rules:
       - ingresses
     verbs:
       - '*'
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+      - scrapeconfigs
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/alloy-operator/templates/rbac.yaml
+++ b/charts/alloy-operator/templates/rbac.yaml
@@ -147,6 +147,14 @@ rules:
       - statefulsets
     verbs:
       - '*'
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
- fixes: https://github.com/grafana/alloy-operator/issues/7
- add missing rbac permissions for networking/ingress api group