### PR TITLE
add missing prometheus permissions

### DIFF
--- a/charts/alloy-operator/templates/rbac.yaml
+++ b/charts/alloy-operator/templates/rbac.yaml
@@ -162,6 +162,8 @@ rules:
       - get
       - list
       - watch
+      - create
+      - patch
   # Rules which allow the management of Ingresses.
   - apiGroups:
       - networking.k8s.io
@@ -177,13 +179,16 @@ rules:
     verbs:
       - '*'
   # Rules which allow mimir.rules.kubernetes to work.
-  - apiGroups: ["monitoring.coreos.com"]
+  - apiGroups: 
+      - "monitoring.coreos.com"
     resources:
       - prometheusrules
     verbs:
       - get
       - list
       - watch
+      - create
+      - patch
   - nonResourceURLs:
       - /metrics
     verbs:


### PR DESCRIPTION
- @stefanandres mentioned in https://github.com/grafana/alloy-operator/pull/14 that there are missing permissions for prometheus objects
- can confirm that serviceMonitor cannot be created at the moment
- added create + patch