### PR TITLE
Remove default resource settings for Grafana Alloy Operator container

### DIFF
--- a/charts/alloy-operator/values.yaml
+++ b/charts/alloy-operator/values.yaml
@@ -97,19 +97,8 @@ service:
     # @section -- Service
     port: 8082
 
-# Sets the resources for the pod.
-resources:
-  # -- Set the resource requests for the pod.
-  # @section -- Resources
-  requests:
-    cpu: 10m
-    memory: 64Mi
-
-  # -- Set the resource limits for the pod.
-  # @section -- Resources
-  limits:
-    cpu: 500m
-    memory: 128Mi
+# -- Resource requests and limits to apply to the Grafana Alloy Operator container.
+resources: {}
 
 # -- Liveness probe settings
 # @section -- Probes


### PR DESCRIPTION
This pull request simplifies remove the default resource setting for the alloy operator container. With this, we follow the standard of other helm charts such as Alloy, Mimir, etc. of not setting requests or limits, avoiding OOM or CPU throttling issues.

Commented on issue https://github.com/grafana/alloy-operator/issues/11