### PR TITLE
Increase operator RBAC permissions to manage VPA resources

### DIFF
--- a/charts/alloy-operator/templates/rbac.yaml
+++ b/charts/alloy-operator/templates/rbac.yaml
@@ -151,6 +151,13 @@ rules:
       - horizontalpodautoscalers
     verbs:
       - '*'
+  # Rules which allow the management of Vertical Pod Autoscalers.
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - '*'
   # Rules which allow for the management of Prometheus Operator objects.
   - apiGroups:
       - monitoring.coreos.com


### PR DESCRIPTION
Hi, alloy team.

I try to deploy alloy-singleton collector and enable VPA, but have error:

```
{"level":"error","ts":"2025-06-11T11:42:16Z","msg":"Reconciler error","controller":"alloy-controller","object":{"name":"k8s-monitoring-alloy-singleton","namespace":"platform-monitoring"},"namespace":"platform-monitoring","name":"k8s-monitoring-alloy-singleton","reconcileID":"092cf519-c141-48a1-ae64-9bc713557ae4","error":"failed to get candidate release: Unable to continue with update: could not get information about the resource VerticalPodAutoscaler \"k8s-monitoring-alloy-singleton\" in namespace \"platform-monitoring\": verticalpodautoscalers.autoscaling.k8s.io \"k8s-monitoring-alloy-singleton\" is forbidden: User \"system:serviceaccount:platform-monitoring:k8s-monitoring-alloy-operator\" cannot get resource \"verticalpodautoscalers\" in API group \"autoscaling.k8s.io\" in the namespace \"platform-monitoring\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.7/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.7/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.7/pkg/internal/controller/controller.go:224"}
```

Operator version is `ghcr.io/grafana/alloy-operator:1.0.3`