### PR TITLE
feat(securityContext): allow users to enable/disable security context

### DIFF
--- a/charts/alloy-operator/README.md
+++ b/charts/alloy-operator/README.md
@@ -40,7 +40,7 @@ A Helm chart the Alloy Operator, a project to innovate on creating instances of 
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Set the node selector for the Alloy Operator pods. |
 | podAnnotations | object | `{}` | Additional annotations to add to the Alloy Operator pods. |
 | podLabels | object | `{}` | Additional labels to add to the Alloy Operator pods. |
-| podSecurityContext | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | Set the security context for the Alloy Operator pods. |
+| podSecurityContext | object | `{"enabled":true,"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | Set the security context for the Alloy Operator pods. Set enabled to false to disable security context entirely. |
 | priorityClassName | string | `""` | Sets the priority class name for the Alloy Operator pods. |
 | tolerations | list | `[]` | Set the tolerations for the Alloy Operator pods. |
 
@@ -114,7 +114,7 @@ A Helm chart the Alloy Operator, a project to innovate on creating instances of 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Set the security context for the operator container. |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"readOnlyRootFilesystem":true}` | Set the security context for the operator container. Set enabled to false to disable security context entirely. |
 
 ### Service
 

--- a/charts/alloy-operator/templates/deployment.yaml
+++ b/charts/alloy-operator/templates/deployment.yaml
@@ -32,8 +32,8 @@ spec:
         {{- end }}
       {{- end }}
       serviceAccountName: {{ include "alloy-operator.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }}
-      securityContext:{{ toYaml . | nindent 8 }}
+      {{- if and .Values.podSecurityContext .Values.podSecurityContext.enabled }}
+      securityContext:{{ toYaml (omit .Values.podSecurityContext "enabled") | nindent 8 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
@@ -84,8 +84,8 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.securityContext }}
-          securityContext:{{- toYaml . | nindent 12 }}
+          {{- if and .Values.securityContext .Values.securityContext.enabled }}
+          securityContext:{{- toYaml (omit .Values.securityContext "enabled") | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/alloy-operator/values.schema.json
+++ b/charts/alloy-operator/values.schema.json
@@ -109,6 +109,9 @@
         "podSecurityContext": {
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "fsGroup": {
                     "type": "integer"
                 },
@@ -173,6 +176,9 @@
         "securityContext": {
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "allowPrivilegeEscalation": {
                     "type": "boolean"
                 },

--- a/charts/alloy-operator/values.yaml
+++ b/charts/alloy-operator/values.yaml
@@ -107,16 +107,20 @@ podLabels: {}
 priorityClassName: ""
 
 # -- Set the security context for the operator container.
+# Set enabled to false to disable security context entirely.
 # @section -- Container Settings
 securityContext:
+  enabled: true
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   capabilities:
     drop: ["ALL"]
 
 # -- Set the security context for the Alloy Operator pods.
+# Set enabled to false to disable security context entirely.
 # @section -- Pod Settings
 podSecurityContext:
+  enabled: true
   fsGroup: 1000
   runAsGroup: 1000
   runAsNonRoot: true


### PR DESCRIPTION
For some OpenShift users, it does require disabling this security contexts, as workaround users can do something like

```yml
alloy-operator:
  podSecurityContext: null
  securityContext: null
```
It works, but Helm’s template engine throws a warning. Using `enable` would be a cleaner way to handle it imho.