### PR TITLE
Add the ability to make pod and container security contexts optional

### DIFF
--- a/charts/alloy-operator/CHANGELOG.md
+++ b/charts/alloy-operator/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Update Operator Framework to 1.42.0 (@petewall)
+* Add the ability to make pod and container security contexts optional, or override the fs, group, and user IDs (@petewall)
 
 ## 0.3.12
 

--- a/charts/alloy-operator/docs/examples/securityContext/disabled/output.yaml
+++ b/charts/alloy-operator/docs/examples/securityContext/disabled/output.yaml
@@ -1,0 +1,268 @@
+---
+# Source: alloy-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-alloy-operator
+  namespace: operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: alloy-operator/templates/rbac/alloy-manager.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-alloy-operator-alloy-manager
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - collectors.grafana.com
+    resources:
+      - alloys
+      - alloys/status
+      - alloys/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+# Source: alloy-operator/templates/rbac/alloy-objects.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-alloy-operator
+rules:
+  # Rules which allow the management of ConfigMaps, ServiceAccounts, and Services.
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "serviceaccounts", "services"]
+    verbs: ["*"]
+  # Rules which allow the management of DaemonSets, Deployments, and StatefulSets.
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "statefulsets"]
+    verbs: ["*"]
+  # Rules which allow the management of Horizontal Pod Autoscalers.
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["*"]
+  # Rules which allow the management of Ingresses and NetworkPolicies.
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["*"]
+  # Rules which allow the management of PodDisruptionBudgets.
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["*"]
+  # Rules which allow the management of ClusterRoles, ClusterRoleBindings, Roles, and RoleBindings.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs: ["*"]
+---
+# Source: alloy-operator/templates/rbac/alloy-manager.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-alloy-operator-alloy-manager
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-alloy-operator-alloy-manager
+subjects:
+  - kind: ServiceAccount
+    name: test-alloy-operator
+    namespace: operator
+---
+# Source: alloy-operator/templates/rbac/alloy-objects.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-alloy-operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-alloy-operator
+subjects:
+  - kind: ServiceAccount
+    name: test-alloy-operator
+    namespace: operator
+---
+# Source: alloy-operator/templates/rbac/leader-election.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-alloy-operator-leader-election-role
+  namespace: operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+# Source: alloy-operator/templates/rbac/leader-election.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-alloy-operator-leader-election-rolebinding
+  namespace: operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-alloy-operator-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: test-alloy-operator
+    namespace: operator
+---
+# Source: alloy-operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-alloy-operator
+  namespace: operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8081
+      targetPort: http
+      protocol: TCP
+    - name: metrics
+      port: 8082
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+---
+# Source: alloy-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-alloy-operator
+  namespace: operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-operator
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: alloy-operator-0.3.12
+        app.kubernetes.io/name: alloy-operator
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: test-alloy-operator
+      containers:
+        - name: alloy-operator
+          image: "ghcr.io/grafana/alloy-operator:1.4.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=:8082
+            - --leader-elect
+            - --leader-election-id=test-alloy-operator
+
+          ports:
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 8082
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits: {}
+            requests: {}
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/charts/alloy-operator/docs/examples/securityContext/disabled/values.yaml
+++ b/charts/alloy-operator/docs/examples/securityContext/disabled/values.yaml
@@ -1,0 +1,2 @@
+podSecurityContext: null
+securityContext: null

--- a/charts/alloy-operator/docs/examples/securityContext/noUserOrGroup/output.yaml
+++ b/charts/alloy-operator/docs/examples/securityContext/noUserOrGroup/output.yaml
@@ -1,0 +1,278 @@
+---
+# Source: alloy-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-alloy-operator
+  namespace: operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: alloy-operator/templates/rbac/alloy-manager.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-alloy-operator-alloy-manager
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - collectors.grafana.com
+    resources:
+      - alloys
+      - alloys/status
+      - alloys/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+# Source: alloy-operator/templates/rbac/alloy-objects.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-alloy-operator
+rules:
+  # Rules which allow the management of ConfigMaps, ServiceAccounts, and Services.
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "serviceaccounts", "services"]
+    verbs: ["*"]
+  # Rules which allow the management of DaemonSets, Deployments, and StatefulSets.
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "statefulsets"]
+    verbs: ["*"]
+  # Rules which allow the management of Horizontal Pod Autoscalers.
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["*"]
+  # Rules which allow the management of Ingresses and NetworkPolicies.
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["*"]
+  # Rules which allow the management of PodDisruptionBudgets.
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["*"]
+  # Rules which allow the management of ClusterRoles, ClusterRoleBindings, Roles, and RoleBindings.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs: ["*"]
+---
+# Source: alloy-operator/templates/rbac/alloy-manager.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-alloy-operator-alloy-manager
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-alloy-operator-alloy-manager
+subjects:
+  - kind: ServiceAccount
+    name: test-alloy-operator
+    namespace: operator
+---
+# Source: alloy-operator/templates/rbac/alloy-objects.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-alloy-operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-alloy-operator
+subjects:
+  - kind: ServiceAccount
+    name: test-alloy-operator
+    namespace: operator
+---
+# Source: alloy-operator/templates/rbac/leader-election.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-alloy-operator-leader-election-role
+  namespace: operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+# Source: alloy-operator/templates/rbac/leader-election.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-alloy-operator-leader-election-rolebinding
+  namespace: operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-alloy-operator-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: test-alloy-operator
+    namespace: operator
+---
+# Source: alloy-operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-alloy-operator
+  namespace: operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8081
+      targetPort: http
+      protocol: TCP
+    - name: metrics
+      port: 8082
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+---
+# Source: alloy-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-alloy-operator
+  namespace: operator
+  labels:
+    helm.sh/chart: alloy-operator-0.3.12
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-operator
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: alloy-operator-0.3.12
+        app.kubernetes.io/name: alloy-operator
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: test-alloy-operator
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: alloy-operator
+          image: "ghcr.io/grafana/alloy-operator:1.4.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=:8082
+            - --leader-elect
+            - --leader-election-id=test-alloy-operator
+
+          ports:
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 8082
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/charts/alloy-operator/docs/examples/securityContext/noUserOrGroup/values.yaml
+++ b/charts/alloy-operator/docs/examples/securityContext/noUserOrGroup/values.yaml
@@ -1,0 +1,4 @@
+podSecurityContext:
+  fsGroup: null
+  runAsGroup: null
+  runAsUser: null

--- a/charts/alloy-operator/schema-mods/types-and-enums.json
+++ b/charts/alloy-operator/schema-mods/types-and-enums.json
@@ -1,5 +1,14 @@
 {
   "properties": {
-    "namespaces": {"items": { "type": "string" }}
+    "namespaces": {"items": { "type": "string" }},
+    "podSecurityContext": {
+      "type": ["null", "object"],
+      "properties": {
+        "fsGroup": {"type": ["null", "integer"]},
+        "runAsGroup": {"type": ["null", "integer"]},
+        "runAsUser": {"type": ["null", "integer"]}
+      }
+    },
+    "securityContext": {"type": ["null", "object"]}
   }
 }

--- a/charts/alloy-operator/values.schema.json
+++ b/charts/alloy-operator/values.schema.json
@@ -107,19 +107,31 @@
             "type": "object"
         },
         "podSecurityContext": {
-            "type": "object",
+            "type": [
+                "null",
+                "object"
+            ],
             "properties": {
                 "fsGroup": {
-                    "type": "integer"
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
                 },
                 "runAsGroup": {
-                    "type": "integer"
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
                 },
                 "runAsNonRoot": {
                     "type": "boolean"
                 },
                 "runAsUser": {
-                    "type": "integer"
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
                 },
                 "seccompProfile": {
                     "type": "object",
@@ -171,7 +183,10 @@
             }
         },
         "securityContext": {
-            "type": "object",
+            "type": [
+                "null",
+                "object"
+            ],
             "properties": {
                 "allowPrivilegeEscalation": {
                     "type": "boolean"


### PR DESCRIPTION
Alternatively, you can disable the fs, group, and user IDs.