### PR TITLE
feat: sign crd and operator charts

### DIFF
--- a/.github/workflows/release-alloy-crd.yaml
+++ b/.github/workflows/release-alloy-crd.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@d7c4f4491dbe46d853833cd15a35159c28061f39
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@hackathon-17-verify-all-the-charts
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release-alloy-operator.yaml
+++ b/.github/workflows/release-alloy-operator.yaml
@@ -4,16 +4,11 @@ name: Release Alloy Operator Helm chart
 on:
   workflow_dispatch:
 
-env:
-  CR_INDEX_PATH: "${{ github.workspace }}/.cr-index"
-  CR_PACKAGE_PATH: "${{ github.workspace }}/.cr-release-packages"
-  CR_TOOL_PATH: "${{ github.workspace }}/.cr-tool"
-
 permissions: {}
 
 jobs:
   release-chart:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@d7c4f4491dbe46d853833cd15a35159c28061f39
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@hackathon-17-verify-all-the-charts
     permissions:
       contents: write
       id-token: write
@@ -27,100 +22,41 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: release-chart
-
-    # These permissions are needed to assume roles from GitHub's OIDC.
     permissions:
-      contents: read
-      id-token: write
-
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          fetch-depth: 0
-          path: source
           persist-credentials: 'false'
-
-      - name: Configure Git
-        run: |
-          cd source
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Install Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
 
       - name: Parse Chart.yaml
         id: parse-chart
-        working-directory: source/charts/alloy-operator
+        working-directory: charts/alloy-operator
         run: |
           name=$(yq ".name" < Chart.yaml)
           version=$(yq ".version" < Chart.yaml)
+          prerelease=false
+          if [[ "$version" == *-* ]]; then
+            prerelease=true
+          fi
           {
-            echo "chartpath=charts/$(basename "$(pwd)")";
             echo "tagname=${name}-${version}";
-            echo "packagename=${name}-${version}";
+            echo "prerelease=${prerelease}";
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Add dependency chart repos
-        env:
-          CHARTPATH: ${{ steps.parse-chart.outputs.chartpath }}
-        working-directory: source
-        run: |
-          # Skip the header line and make sure that tabs are expanded into spaces
-          deps=$(helm dependency list "${CHARTPATH}" | tail +2 | expand)
-          while read -r row; do
-            IFS=' ' read -ra parts <<< "$row"
-            name="${parts[0]}"
-            repo="${parts[2]}"
-            case "$repo" in
-              "https://"*) helm repo add "$name" "$repo" ;;
-              *) echo >&2 "Skipping dependency $name: unsupported schema for \"$repo\"" ;;
-            esac
-          done <<< "$deps"
-
-      - name: Get GitHub App token
-        id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
-        with:
-          github_app: alloy-operator
-
-      - name: Set the token
-        env:
-          APP_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
-        run: echo "AUTHTOKEN=${APP_TOKEN}" >> "${GITHUB_ENV}"
-
-      - name: Install CR tool
-        env:
-          GITHUB_TOKEN: ${{ env.AUTHTOKEN }}
-        run: |
-          mkdir "${CR_TOOL_PATH}"
-          mkdir "${CR_PACKAGE_PATH}"
-          mkdir "${CR_INDEX_PATH}"
-          crVersion=$(gh release list --repo helm/chart-releaser --exclude-pre-releases --json tagName --jq '.[0].tagName' | sed 's/v//')
-          curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/v${crVersion}/chart-releaser_${crVersion}_linux_amd64.tar.gz"
-          tar -xzf cr.tar.gz -C "${CR_TOOL_PATH}"
-          rm -f cr.tar.gz
-
-      - name: Create Helm package
-        env:
-          CHARTPATH: ${{ steps.parse-chart.outputs.chartpath }}
-        working-directory: source
-        run: |
-          "${CR_TOOL_PATH}/cr" package "${CHARTPATH}" --config cr.yaml --package-path "${CR_PACKAGE_PATH}"
-          echo "Result of chart package:"
-          cp charts/alloy-crd/crds/collectors.grafana.com_alloy.yaml "${CR_PACKAGE_PATH}/collectors.grafana.com_alloy.yaml"
-          ls -l "${CR_PACKAGE_PATH}"
-
       - name: Make GitHub release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
-        with:
-          name: ${{ steps.parse-chart.outputs.tagname }}
-          repository: grafana/alloy-operator
-          generate_release_notes: true
-          files: |
-            ${{ env.CR_PACKAGE_PATH }}/${{ steps.parse-chart.outputs.packagename }}.tgz
-            ${{ env.CR_PACKAGE_PATH }}/collectors.grafana.com_alloy.yaml
-          tag_name: ${{ steps.parse-chart.outputs.tagname }}
-          token: ${{ env.AUTHTOKEN }}
-          fail_on_unmatched_files: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAGNAME: ${{ steps.parse-chart.outputs.tagname }}
+          PRERELEASE: ${{ steps.parse-chart.outputs.prerelease }}
+        run: |
+          prerelease_flag=""
+          if [[ "${PRERELEASE}" == "true" ]]; then
+            prerelease_flag="--prerelease"
+          fi
+          gh release create "${TAGNAME}" \
+            --title "${TAGNAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --notes "Chart released at https://github.com/grafana/helm-charts/releases/tag/${TAGNAME}" \
+            ${prerelease_flag}

--- a/cr.yaml
+++ b/cr.yaml
@@ -3,3 +3,4 @@ owner: grafana
 git-repo: helm-charts
 skip-existing: true
 release-name-template: "{{ .Name }}-{{ .Version }}"
+sign: true


### PR DESCRIPTION
As part of Hackathon 17 we're adding signing support to our helm charts via the `update-helm-repo` action. You can see this in action [here](https://github.com/grafana/k8s-manifest-tail/releases/tag/k8s-manifest-tail-0.1.5).

Draft until we get the proper secrets setup.