### PR TITLE
feat: support global.image.pullPolicy

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -239,9 +239,8 @@ MD052: true
 # MD053/link-image-reference-definitions - Link and image reference definitions should be needed
 MD053:
   # Ignored definitions
-  ignored_definitions: [
-    "//"
-  ]
+  ignored_definitions:
+    - "//"
 
 # MD060/table-column-style - Disabling because helm-docs is inconsistent
 MD060: false

--- a/charts/alloy-operator/CHANGELOG.md
+++ b/charts/alloy-operator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Support `global.image.pullPolicy` as an alternative to `global.imagePullPolicy`, matching the nested `global.image.*` convention already used for the image registry and pull secrets (@TylerHelmuth)
+* Deprecate `global.imageRegistry` and `global.imagePullPolicy` in favor of `global.image.registry` and `global.image.pullPolicy`. Setting a deprecated key at the same time as its `global.image.*` counterpart now fails rendering (@TylerHelmuth)
+
 ## 0.5.11
 
 * Include signed Alloy CRD chart (@petewall)

--- a/charts/alloy-operator/README.md
+++ b/charts/alloy-operator/README.md
@@ -74,9 +74,11 @@ A Helm chart the Alloy Operator, a project to innovate on creating instances of 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| global.image.pullPolicy | string | `""` | Global image pull policy override. |
 | global.image.pullSecrets | list | `[]` | Global image pull secrets. |
-| global.imagePullPolicy | string | `""` | Global image pull policy override. |
-| global.imageRegistry | string | `""` | Global image registry override. |
+| global.image.registry | string | `""` | Global image registry override. |
+| global.imagePullPolicy | string | `""` | DEPRECATED: use `global.image.pullPolicy` instead. Cannot be set at the same time as `global.image.pullPolicy`. |
+| global.imageRegistry | string | `""` | DEPRECATED: use `global.image.registry` instead. Cannot be set at the same time as `global.image.registry`. |
 | image.digest | string | `""` | Alloy Operator image digest. If set, will override the tag. Format: sha256:&lt;digest&gt;. |
 | image.pullPolicy | string | `"IfNotPresent"` | The pull policy for images. |
 | image.pullSecrets | list | `[]` | Optional set of image pull secrets. |

--- a/charts/alloy-operator/templates/_helpers.tpl
+++ b/charts/alloy-operator/templates/_helpers.tpl
@@ -61,6 +61,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- ((.Values.global).imageRegistry) | default (((.Values.global).image).registry) | default .Values.image.registry -}}
 {{- end -}}
 
+{{/* Calculate the image pull policy to use */}}
+{{- define "alloy-operator.imagePullPolicy" -}}
+{{- ((.Values.global).imagePullPolicy) | default (((.Values.global).image).pullPolicy) | default .Values.image.pullPolicy -}}
+{{- end -}}
+
 {{/* Calculate the image identifier to use */}}
 {{- define "alloy-operator.imageIdentifier" -}}
 {{- if .Values.image.digest }}

--- a/charts/alloy-operator/templates/deployment.yaml
+++ b/charts/alloy-operator/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ include "alloy-operator.imageRegistry" . }}/{{ .Values.image.repository }}{{ include "alloy-operator.imageIdentifier" . }}"
-          imagePullPolicy: {{ .Values.global.imagePullPolicy | default .Values.image.pullPolicy }}
+          imagePullPolicy: {{ include "alloy-operator.imagePullPolicy" . }}
           args:
             - --health-probe-bind-address=:{{ .Values.service.health.port }}
             - --metrics-bind-address=:{{ .Values.service.metrics.port }}

--- a/charts/alloy-operator/templates/image-validation.yaml
+++ b/charts/alloy-operator/templates/image-validation.yaml
@@ -1,0 +1,19 @@
+---
+{{- if and ((.Values.global).imageRegistry) (((.Values.global).image).registry) }}
+  {{- $msg := list "" "global.imageRegistry is deprecated and cannot be set at the same time as global.image.registry." }}
+  {{- $msg = append $msg "Please set only global.image.registry:" }}
+  {{- $msg = append $msg "alloy-operator:" }}
+  {{- $msg = append $msg "  global:" }}
+  {{- $msg = append $msg "    image:" }}
+  {{- $msg = append $msg "      registry: my-registry.example.com" }}
+  {{- fail (join "\n" $msg) }}
+{{- end }}
+{{- if and ((.Values.global).imagePullPolicy) (((.Values.global).image).pullPolicy) }}
+  {{- $msg := list "" "global.imagePullPolicy is deprecated and cannot be set at the same time as global.image.pullPolicy." }}
+  {{- $msg = append $msg "Please set only global.image.pullPolicy:" }}
+  {{- $msg = append $msg "alloy-operator:" }}
+  {{- $msg = append $msg "  global:" }}
+  {{- $msg = append $msg "    image:" }}
+  {{- $msg = append $msg "      pullPolicy: Always" }}
+  {{- fail (join "\n" $msg) }}
+{{- end }}

--- a/charts/alloy-operator/tests/image-settings_test.yaml
+++ b/charts/alloy-operator/tests/image-settings_test.yaml
@@ -63,13 +63,12 @@ tests:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
 
-  - it: prefers global.imageRegistry over global.image.registry
+  - it: uses global.image.pullPolicy for backwards compatibility
     set:
       global:
-        imageRegistry: preferred-registry.example.com
         image:
-          registry: old-registry.example.com
+          pullPolicy: Always
     asserts:
-      - matchRegex:
-          path: spec.template.spec.containers[0].image
-          pattern: "^preferred-registry\\.example\\.com/grafana/alloy-operator:"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always

--- a/charts/alloy-operator/tests/image-validation_test.yaml
+++ b/charts/alloy-operator/tests/image-validation_test.yaml
@@ -1,0 +1,70 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Test - Alloy Operator - Image Validation
+templates:
+  - image-validation.yaml
+tests:
+  - it: passes by default
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: passes when only global.image.registry is set
+    set:
+      global:
+        image:
+          registry: my-registry.example.com
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: passes when only global.imageRegistry is set
+    set:
+      global:
+        imageRegistry: my-registry.example.com
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: fails when both global.imageRegistry and global.image.registry are set
+    set:
+      global:
+        imageRegistry: my-registry.example.com
+        image:
+          registry: my-registry.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            global.imageRegistry is deprecated and cannot be set at the same time as global.image.registry.
+            Please set only global.image.registry:
+            alloy-operator:
+              global:
+                image:
+                  registry: my-registry.example.com
+
+  - it: passes when only global.image.pullPolicy is set
+    set:
+      global:
+        image:
+          pullPolicy: Always
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: passes when only global.imagePullPolicy is set
+    set:
+      global:
+        imagePullPolicy: Always
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: fails when both global.imagePullPolicy and global.image.pullPolicy are set
+    set:
+      global:
+        imagePullPolicy: Always
+        image:
+          pullPolicy: Always
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            global.imagePullPolicy is deprecated and cannot be set at the same time as global.image.pullPolicy.
+            Please set only global.image.pullPolicy:
+            alloy-operator:
+              global:
+                image:
+                  pullPolicy: Always

--- a/charts/alloy-operator/values.schema.json
+++ b/charts/alloy-operator/values.schema.json
@@ -33,8 +33,14 @@
                         },
                         "pullSecrets": {
                             "type": "array"
+                        },
+                        "registry": {
+                            "type": "string"
                         }
                     }
+                },
+                "imagePullPolicy": {
+                    "type": "string"
                 },
                 "imageRegistry": {
                     "type": "string"

--- a/charts/alloy-operator/values.yaml
+++ b/charts/alloy-operator/values.yaml
@@ -17,15 +17,23 @@ global:
   # @section -- Deployment Settings
   namespaceOverride: ""
 
-  # -- Global image registry override.
+  # -- DEPRECATED: use `global.image.registry` instead. Cannot be set at the same time as `global.image.registry`.
   # @section -- Image Settings
   imageRegistry: ""
 
-  # -- Global image pull policy override.
+  # -- DEPRECATED: use `global.image.pullPolicy` instead. Cannot be set at the same time as `global.image.pullPolicy`.
   # @section -- Image Settings
   imagePullPolicy: ""
 
   image:
+    # -- Global image registry override.
+    # @section -- Image Settings
+    registry: ""
+
+    # -- Global image pull policy override.
+    # @section -- Image Settings
+    pullPolicy: ""
+
     # -- Global image pull secrets.
     # @section -- Image Settings
     pullSecrets: []


### PR DESCRIPTION
This chart supports a mix of `global.image.*` and `global.image*`. This PR updates the chart to use `global.image.*` like our other charts. It deprecates `global.imagePullPolicy` and `global.imageRegistry`.

Related to https://github.com/grafana/k8s-monitoring-helm/issues/2498