### PR TITLE
Attach Alloy CRD to operator GitHub releases

### DIFF
--- a/.github/workflows/release-alloy-operator.yaml
+++ b/.github/workflows/release-alloy-operator.yaml
@@ -59,4 +59,5 @@ jobs:
             --title "${TAGNAME}" \
             --repo "${GITHUB_REPOSITORY}" \
             --notes "Chart released at https://github.com/grafana/helm-charts/releases/tag/${TAGNAME}" \
-            ${prerelease_flag}
+            ${prerelease_flag} \
+            charts/alloy-crd/crds/collectors.grafana.com_alloy.yaml


### PR DESCRIPTION
## What

Re-attaches the Alloy CRD (`collectors.grafana.com_alloy.yaml`) as an asset on the operator's GitHub releases.

## Why

When the release workflow was simplified to use `gh release create` (replacing `softprops/action-gh-release`), it stopped attaching the CRD file. As a result, `0.6.0` and `0.6.1` shipped without it. The [K8s Monitoring docs](https://github.com/grafana/alloy-operator/issues/197) link to this asset for users who need to install the CRD manually.

The previous workflow explicitly attached `collectors.grafana.com_alloy.yaml`; this restores that behavior by passing the CRD as a positional file argument to `gh release create`.

Fixes #197